### PR TITLE
fix the too-long issue of header line

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@ Page does not exist at {{ SITENAME|striptags }} blog.
 {% endblock head_description %}
 {% block content %}
 <div class="row-fluid">
-    <header class="page_header span10 offset2">
+    <header class="page_header span8 offset2">
     <h1>That page doesn't exist!</h1>
     </header>
 </div>

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -10,7 +10,7 @@ Full archives of {{ SITENAME|striptags }} blog.
 {% block content %}
 
 <div class="row-fluid">
-    <header class="page_header span10 offset2">
+    <header class="page_header span8 offset2">
     <h1><a href="/archives.html">All Posts</a></h1>
     </header>
 </div>

--- a/templates/article.html
+++ b/templates/article.html
@@ -19,7 +19,7 @@
 {% block content %}
 <article>
 <div class="row-fluid">
-    <header class="page_header span10 offset2">
+    <header class="page_header span8 offset2">
     <h1><a href="{{ SITEURL }}/{{ article.url }}"> {{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></h1>
     </header>
 </div>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -9,7 +9,7 @@ All categories of the {{ SITENAME|striptags }} blog.
 {% endblock head_description %}
 {% block content %}
 <div class="row-fluid">
-    <header class="page_header span10 offset2">
+    <header class="page_header span8 offset2">
     <h1><a href="/categories.html">All Categories</a></h1>
     </header>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@ Home page of the {{ SITENAME|striptags }} blog.
 {% block content %}
 <div class="row-fluid">
     {% if LANDING_PAGE_ABOUT and LANDING_PAGE_ABOUT.title %}
-    <header class="page_header span12">
+    <header class="page_header span8 offset2">
     <h1><a href="{{ SITEURL }}">{{ LANDING_PAGE_ABOUT.title }}</a></h1>
     </header>
     {% endif %}
@@ -44,7 +44,7 @@ Home page of the {{ SITENAME|striptags }} blog.
 
     {% if articles %}
     <div class="row-fluid">
-        <div class="span12">
+        <div class="span8 offset2">
             <header>
             <h1 id="recent-posts">Recent Posts <a id="allposts" href="{{ SITEURL }}/archives.html">all posts</a></h1>
             </header>

--- a/templates/page.html
+++ b/templates/page.html
@@ -19,7 +19,7 @@
 {% block content %}
 <article>
 <div class="row-fluid">
-    <header class="page_header span10 offset2">
+    <header class="page_header span8 offset2">
     <h1><a href="{{ SITEURL }}/{{ page.url }}"> {{ page.title }} {%if page.subtitle %} <small> {{ page.subtitle }} </small> {% endif %} </a></h1>
     </header>
 </div>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -10,7 +10,7 @@ All tags used in the {{ SITENAME|striptags }} blog.
 {% block content %}
 
 <div class="row-fluid">
-    <header class="page_header span10 offset2">
+    <header class="page_header span8 offset2">
     <h1><a href="/tags.html">All Tags</a></h1>
     </header>
 </div>


### PR DESCRIPTION
Hi, talha131, I tried your pelican theme elegant, it's awesome, clean and elegant.

But I find the header line of some pages is too long, e.g. archive.html, tags.html. "span10" makes sense for article.html, cause it needs to cover the side bar column. But it looks weird in archive.html, tags.html, categories.html, when there is no side bar. So I guess perhaps it's a bug?
