### PR TITLE
Fix the placement of `div.recent-posts time` for small screen.

### DIFF
--- a/static/css/elegant.css
+++ b/static/css/elegant.css
@@ -590,11 +590,6 @@ div.recent-posts time {
         margin-left: 0;
         padding-left: 0;
     }
-    div.recent-posts time {
-        display: block;
-        float: none;
-        text-align: left;
-    }
 }
 /* MailChimp */
 #mc-embed-signup {


### PR DESCRIPTION
related to #59, fixed a date position bug mentioned in https://github.com/talha131/pelican-elegant/issues/59#issuecomment-29157940.

> It you change the browser window size to small. Date will appear under category.
> When you change the window size back to normal, date still appears on an empty line.
