### PR TITLE
Minor fixes for browsing off via file URLs (RELATIVE_URLS=True).

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,8 +22,8 @@
         {% endblock meta_tags_in_head %}
         <title>{% block title %}{{ SITENAME|striptags }}{% endblock title %}</title>
         {% block head_links %}
-        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
-        <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.1/css/font-awesome.css" rel="stylesheet">
+        <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
+        <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.1/css/font-awesome.css" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/elegant.css" media="screen">
         {%if CUSTOM_CSS %}
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/custom.css" media="screen">
@@ -45,10 +45,10 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </a>
-                    <a class="brand" href="{{ SITEURL }}/"><span class=site-name>{{ SITENAME }}</span></a>
+                    <a class="brand" href="{{ SITEURL }}/{% if RELATIVE_URLS %}index.html{% endif %}"><span class=site-name>{{ SITENAME }}</span></a>
                     <div class="nav-collapse collapse">
                         <ul class="nav pull-right top-menu">
-                            <li {% if page_name == 'index' %} class="active"{% endif %}><a href="{{ SITEURL }}">Home</a></li>
+                            <li {% if page_name == 'index' %} class="active"{% endif %}><a href="{{ SITEURL }}/{% if RELATIVE_URLS %}index.html{% endif %}">Home</a></li>
                             {% if DISPLAY_PAGES_ON_MENU %}
                             {% for page in pages %}
                             <li {% if output_file == page.url %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
@@ -77,7 +77,7 @@
         {% include 'footer.html' %}
         {% block script %}
         <script src="http://code.jquery.com/jquery.min.js"></script>
-        <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
+        <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
         <script>
             function validateForm(query)
             {


### PR DESCRIPTION
When using pelican-elegant with RELATIVE_URLS=True there are a few minor issues this corrects:
1. The bootstrap CSS won't load due to lacking http: at the start of the URL.
2. Home and site link take you to the directory, which just gives you a list of files if running directory off the filesystem.
