### PR TITLE
Make jquery resource use default page scheme

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -93,7 +93,7 @@
     </div>
         {% include '_includes/footer.html' %}
         {% block script %}
-        <script src="http://code.jquery.com/jquery.min.js"></script>
+        <script src="//code.jquery.com/jquery.min.js"></script>
         <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
         <script>
             function validateForm(query)

--- a/templates/search.html
+++ b/templates/search.html
@@ -25,7 +25,7 @@ Search results for {{ SITENAME|striptags|e }} blog.
 {% endblock meta_tags_in_head %}
 
 {% block script %}
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
     {% if 'assets' in PLUGINS %}
     {% include '_includes/minify_tipuesearch.html' with context %}
     {% else %}


### PR DESCRIPTION
The scheme for the JQuery URL should match that of the page. This prevents security warnings and page errors when the rest of the page is served through TLS.
