### PR TITLE
Include summaries in the recent articles list if RECENT_ARTICLE_SUMMARY is set.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -103,7 +103,7 @@
                 </div>
                 </section>
                 {% if RECENT_ARTICLE_SUMMARY %}
-                <p>{{article.summary|striptags}}</p>
+                <p>{{article.summary}}</p>
                 <footer>
                   <a href="{{ SITEURL }}/{{ article.url }}">Continue reading →</a>
                 </footer>

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,6 +102,12 @@
                 <time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
                 </div>
                 </section>
+                {% if RECENT_ARTICLE_SUMMARY %}
+                <p>{{article.summary|striptags}}</p>
+                <footer>
+                  <a href="{{ SITEURL }}/{{ article.url }}">Continue reading →</a>
+                </footer>
+                {% endif %}
             </article>
             {% endif %}
             {% endfor %}


### PR DESCRIPTION
As mentioned in #120, I would like to have summaries on my "recent articles" list on the main page. I have resurrected the relevant part of the template from the revision mentioned there and wrapped it in a check for the presence of the (new) `RECENT_ARTICLE_SUMMARY` config variable.

As I suspected, the styling isn't quite right and will probably have to be tweaked by someone with more skill than I in that area. (If you decide that this isn't something you want in your theme, I'm happy to maintain my own fork for my personal webite.)
