### PR TITLE
Add footnote superscript

### DIFF
--- a/static/css/elegant.css
+++ b/static/css/elegant.css
@@ -602,4 +602,9 @@ div.figure.align-left, .article-content img.align-left {
     float: left;
     margin-right: 1.5em;
 }
+.footnote-reference {
+  font-size: xx-small;
+  vertical-align: super;
+  line-height: 0em;
+}
 


### PR DESCRIPTION
In reStructuredText, a class of footnote-reference is applied to footnotes. No reason not to take advantage of that, eh?
