### PR TITLE
Parameterise 3rd party urls 

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -41,7 +41,7 @@
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/pygments.css" media="screen">
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/tipuesearch/tipuesearch.css" media="screen">
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/elegant.css" media="screen">
-        <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/custom.css" media="screen">
+        <link rel="stylesheet" type="text/css" href="{{ SITEURL }}{{ CUSTOM_CSS | default('/theme/css/custom.css') }}" media="screen">
         {% endif %}
         {% endblock head_links %}
         {% include '_includes/favicon_links.html' %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="{{ DEFAULT_LANG | default('en-US') }}">
     <head>
-        <meta charset="utf-8"> 
+        <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         {% if article and article.author %}
@@ -33,8 +33,8 @@
         {% endblock meta_tags_in_head %}
         <title>{% block title %}{{ SITENAME|striptags|e }}{% endblock title %}</title>
         {% block head_links %}
-        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
-        <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.1/css/font-awesome.css" rel="stylesheet">
+        <link href="{{ TWITTER_BOOTSTRAP_CSS_URL | default('//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css') }}" rel="stylesheet">
+        <link href="{{ FONTAWESOME_URL | default('//netdna.bootstrapcdn.com/font-awesome/4.0.1/css/font-awesome.css') }}" rel="stylesheet">
         {% if 'assets' in PLUGINS %}
         {% include '_includes/minify_css.html' with context %}
         {% else %}
@@ -93,7 +93,7 @@
         {% include '_includes/footer.html' %}
         {% block script %}
         <script src="http://code.jquery.com/jquery.min.js"></script>
-        <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
+        <script src="{{ TWITTER_BOOTSTRAP_JS_URL | default('//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js') }}"></script>
         <script>
             function validateForm(query)
             {

--- a/templates/search.html
+++ b/templates/search.html
@@ -25,7 +25,7 @@ Search results for {{ SITENAME|striptags|e }} blog.
 {% endblock meta_tags_in_head %}
 
 {% block script %}
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
+<script src="{{ JQUERY_URL | default('http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js') }}"></script>
     {% if 'assets' in PLUGINS %}
     {% include '_includes/minify_tipuesearch.html' with context %}
     {% else %}


### PR DESCRIPTION
Why??

I like the elegant theme but wanted to use a gitlab social icon. That meant updating the fontawesome version used.

I also wanted to change some colours with the custom.css.

Fix
Rather than maintain a fork with my changes, I parameterised a few of the urls in base.html

different 3rd party urls can now be used with some variables in config.

- `TWITTER_BOOTSTRAP_CSS_URL`
- `TWITTER_BOOTSTRAP_JS_URL`
- `FONTAWESOME_URL`
- `CUSTOM_CSS`
- `JQUERY_URL`

The existing hard coded urls have been left in as the defaults to ensure out of the box functionality

As I was working I also fixed #156 but again defaults to the existing hardcoded value ('en-US')