### PR TITLE
Adds author blurbs to the end of each article

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ Version 2.0 (under development)
 * Add Disqus comments to Pages
 * All customizable variables consolidated in a single `_defaults.html`, making
   it easier for you to customize or even *localize* the theme
+* Adds author blurbs at the end of the article
 
 Performance
 -----------

--- a/static/css/elegant.css
+++ b/static/css/elegant.css
@@ -603,4 +603,11 @@ div.figure.align-left, .article-content img.align-left {
     float: left;
     margin-right: 1.5em;
 }
-
+/* Author blurb */
+.author_blurb {
+    font-variant: small-caps;
+    font-style: italic;
+}
+.author_name {
+    font-weight: bold;
+}

--- a/templates/_includes/article_author.html
+++ b/templates/_includes/article_author.html
@@ -1,0 +1,10 @@
+{% macro article_author(article) %}
+<div>
+    {% for author in article.authors %}
+        {% if author|string in AUTHORS %}
+            <span class="author_blurb"><a href="{{ AUTHORS.get(author|string).url }}"><span class="author_name">{{ author }}</span></a> -
+                {{ AUTHORS.get(author|string).blurb }}</span><br />
+        {% endif %}
+    {% endfor %}
+</div>
+{% endmacro %}

--- a/templates/article.html
+++ b/templates/article.html
@@ -44,6 +44,8 @@
             {% import '_includes/translations.html' as translations with context %}
             {{ translations.translations_for(article) }}
             {{ article.content }}
+            {% from '_includes/article_author.html' import article_author with context %}
+            {{ article_author(article) }}
             {% from '_includes/share_links.html' import share_links with context %}
             {{ share_links(article) }}
             {% from '_includes/comments.html' import comments with context %}


### PR DESCRIPTION
Refs #185

This will:

    - work with the default author in the configuration file as long as they are listed in the `AUTHORS` dictionary
    - work with and display multiple `authors:` as long as all are listed in the `AUTHORS` dictionary
    - work with a single `author:` listed as long as they are listed in the dictionary. This method is useful for over riding the default author
    - work with multiple `authors:` even if one or more aren't in the dictionary. This will only generate a blurb for the known author(s) and the others won't be listed.
    - work with a single author even if the `authors:` meta tag is used.

This will not:

    - generate a blurb for anyone that does not have an entry in `AUTHORS`
    - work if a user uses the `author:` meta tag improperly by specifying multiple authors. In this case, no blurb will be generated. The correct way to handle this is to use `authors:`