### PR TITLE
Fix HTML5 compatibility

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -46,19 +46,19 @@ Full archives of {{ SITENAME|striptags|e }} blog.
                 {% endif %}
 
                 {% if loop.last %}
-                    <article class="last-entry-of-year">
+                    <article itemscope class="last-entry-of-year">
                 {% else %}
                 {% set next_year = loop.nextitem.date.strftime('%Y') %}
 
                     {% if next_year != year %}
-                        <article class="last-entry-of-year">
+                        <article itemscope class="last-entry-of-year">
                     {% else %}
-                        <article>
+                        <article itemscope>
                     {% endif %}
                 {% endif %}
 
                 <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a>
-                <time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
+                <time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
                 </article>
             {% endfor %}
         </div>

--- a/templates/article.html
+++ b/templates/article.html
@@ -21,7 +21,7 @@
 {% endblock meta_tags_in_head %}
 
 {% block content %}
-<article>
+<article itemscope>
 <div class="row-fluid">
     <header class="page-header span10 offset2">
     <h1><a href="{{ SITEURL }}/{{ article.url }}"> {{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></h1>
@@ -84,7 +84,7 @@
             {% if article.date %}
             <h4>Published</h4>
             {% set day = article.date.strftime('%d')|int %}
-            <time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b') }} {{ day }} {{- article.date.strftime(', %Y') }}</time>
+            <time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b') }} {{ day }} {{- article.date.strftime(', %Y') }}</time>
             {% endif %}
             {% include '_includes/last_updated.html' %}
             {% include '_includes/series.html' %}

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -52,7 +52,7 @@ All categories of the {{ SITENAME|striptags|e }} blog.
                     <div class="accordion-inner">
                         <ul class="list-articles-category">
                             {% for article in articles %}
-                            <li><time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></li>
+                            <li itemscope><time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></li>
                             {% endfor %}
                         </ul>
                     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,13 +93,13 @@
             {% for article in articles %}
             {% from '_includes/_defaults.html' import RECENT_ARTICLES_COUNT with context %}
             {% if loop.index0 < RECENT_ARTICLES_COUNT %}
-            <article>
+            <article itemscope>
                 <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a>
                 <section>
                     posted in
                 <a href="{{ SITEURL }}/{{ CATEGORIES_URL|default('categories') }}#{{ article.category.slug }}-ref">{{ article.category }}</a>
                 <div class="recent-posts-time">
-                <time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
+                <time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
                 </div>
                 </section>
                 {% if RECENT_ARTICLE_SUMMARY %}

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -58,7 +58,7 @@ All tags used in the {{ SITENAME|striptags|e }} blog.
         <h2 id="{{ tag.slug }}-ref" class="tag-title">{{ tag }}</h2>
         <ul class="articles-in-tag list-articles-category">
             {% for article in articles|sort(reverse = true, attribute = 'date') %}
-            <li><time pubdate="pubdate" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></li>
+            <li itemscope><time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }} {%if article.subtitle %} <small> {{ article.subtitle }} </small> {% endif %} </a></li>
             {% endfor %}
         </ul>
 


### PR DESCRIPTION
- fixed date stamps to be HTML5 valid
- add `itemscope` to `<article>`

What I ommitted, but may need to fix later, if HTML5 hasn’t
included it yet:

- remove: `<meta name="copyright" content="{{ AUTHOR }}" />`

Also see https://github.com/Pelican-Elegant/elegant/pull/151 for a reference of an earlier failed attempt.