### PR TITLE
Allow to 'jump' to another url from article slug

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -11,6 +11,9 @@
 {% endblock head_description %}
 
 {% block meta_tags_in_head %}
+{% if article.jump %}
+<meta http-equiv="refresh" content="0;URL={{ article.jump}}" />
+{% endif %}
 {{ super() }}
 {% if article.tags or article.category or article.keywords %}
 <meta name="keywords" content="{{ [article.tags|join(', '), article.category, article.keywords]|join(', ') }}" />


### PR DESCRIPTION
Closes #238 

Article yaml preamble with 'jump' gets added as META redirect