### PR TITLE
Docs: Changes to search article to be more accurate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **admonition:** links should inherit the admonition color ([60c9184](https://github.com/Pelican-Elegant/elegant/commit/60c9184))
 - **freelists:** use SUBSCRIBE_BUTTON_TITLE instead of generic GO ([c346d1f](https://github.com/Pelican-Elegant/elegant/commit/c346d1f))
 - **home:** remove redundant title ([808cd1d](https://github.com/Pelican-Elegant/elegant/commit/808cd1d))
+- **docs:** changed docs for search engine to be more clear
 
 ### Features
 

--- a/documentation/content/Search/tipue-search.md
+++ b/documentation/content/Search/tipue-search.md
@@ -1,5 +1,5 @@
 ---
-authors: Talha Mansoor
+authors: Talha Mansoor, Jack De Winter
 Title: Add Search to your Site
 Tags: unique
 Date: 2019-07-03 19:56
@@ -8,24 +8,27 @@ Summary: Elegant lets you add search to your static site
 Category: Search
 ---
 
-Static sites usually do not offer search. Elegant uses [Tipue
-Search](http://www.tipue.com/search/)- an open source jQuery plugin, to offer
+Static sites usually do not offer search, as they are normally considered a dynamic task.
+Elegant uses the open-source [Tipue Search](http://www.tipue.com/search/) plugin, to offer
 search for your static site.
 
-Here is how the search result looks like
+Here is an example of what the search result may look like:
 
 ![Search result for App Store]({static}/images/elegant-theme_search-result.png)
 
-Search box is part of main navigation menu so that visitor can search from any
-page.
+We have located the search box on the top right of the main navigation menu to allow
+visitors to search from any page.
 
 ![Search box]({static}/images/elegant-theme_search-box.png)
 
 ## Configuration
 
-To enable search, you need to enable `tipue_search` plugin and add `search` to `DIRECT_TEMPLATES` in your pelican configuration
+To enable search, you need to enable `tipue_search` plugin and add `search` to `DIRECT_TEMPLATES` in your pelican configuration.
 
 ```python
-PLUGINS = [tipue_search']
-DIRECT_TEMPLATES = (('index', 'tags', 'categories','archives', 'search'))
+PLUGINS = ['tipue_search']
+DIRECT_TEMPLATES = ['search']
 ```
+
+Note that these values must be added to any existing values present for the `PLUGINS` and
+`DIRECT_TEMPLATES` configuration variables.


### PR DESCRIPTION
## Description

Updated the documentation for the tipue-search.md file to be more clear and to provide a more correct instruction on adding the values.

Note that before, the values were in (( )), in the pelicanconf.py for elegant they are ( ), and on the the pelican site they are [ ].  Note that [ ] and ( ) will both work if you are using numerical indices to retrieve the information.
