### PR TITLE
Feature: Change base template for error pages when on GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **home:** write about me in markdown, reST or AsciiDoc ([9b5b2ec](https://github.com/Pelican-Elegant/elegant/commit/9b5b2ec)), closes [#85](https://github.com/Pelican-Elegant/elegant/issues/85)
 - **menu:** set home URL to root if SITEURL is not ([23e0b94](https://github.com/Pelican-Elegant/elegant/commit/23e0b94))
+- **404:** if SITE_URL is set to a GitHub Pages site, add the proper header information
 
 ### BREAKING CHANGES
 

--- a/documentation/pelicanconf.py
+++ b/documentation/pelicanconf.py
@@ -161,4 +161,8 @@ AUTHORS = {
         "url": "http://iranzo.github.io",
         "blurb": " opensource enthusiast and Lego fan doing some python simple programs like @redken_bot in telegram, etc",
     },
+    "Jack De Winter": {
+        "url": "http://jackdewinter.github.io",
+        "blurb": "ever evolving, ever learning",
+    },
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,8 @@
+{% if SITEURL.endswith('.github.io') and page_name == '404'%}
+---
+permalink: /404.html
+---
+{% endif %}
 <!DOCTYPE html>
 <html lang="{{ DEFAULT_LANG | default("en-US") }}">
     <head>


### PR DESCRIPTION
## Description

Per [GitHub Pages](https://help.github.com/en/articles/creating-a-custom-404-page-for-your-github-pages-site), if you want an error page to be used, you need to mark it with a Jekyll header.

This feature (not really a bug?) adds template information to detect if the page is a 404 page and if the site being published to ends in ".github.io" and adds that header.

Note that in the future, to support CNAME'd GitHub Pages, we may want to make this a auto-detect OR override with a configuration variable.