### PR TITLE
Meta tags in frontpage

### DIFF
--- a/documentation/content/Analytics SEO SMO/claim-site.md
+++ b/documentation/content/Analytics SEO SMO/claim-site.md
@@ -1,6 +1,6 @@
 ---
-Title: Claim website on Google and Bing
-Tags: google, bing, crawler
+Title: Claim website on Google, Yandex and Bing
+Tags: google, bing, yandex, crawler
 Category: Analytics, SEO and SMO
 Date: 2019-06-27
 Slug: website-claim
@@ -10,8 +10,7 @@ Summary: Easily insert headers to claim website
 Keywords:
 ---
 
-For submitting a website and sitemap to Google Search Console or Bing Webmaster tools
-we've to consider some steps.
+For submitting a website and sitemap to Google Search Console or Bing Webmaster tools or Yandex Webmaster we've to consider some steps.
 
 One of those steps is to claim the website ownership.
 
@@ -33,11 +32,13 @@ headers:
 
 - `CLAIM_GOOGLE`
 - `CLAIM_BING`
+- `CLAIM_YANDEX`
 
 Each one of those should be filled according to the values provided by
 Google/Bing on their respective websites for webmasters:
 
 - [Google Search Console](https://www.google.com/webmasters/tools/dashboard?pli=1)
 - [Bing Webmaster tools](https://www.bing.com/webmaster/configure/verify/ownership)
+- [Yandex Webmaster](https://webmaster.yandex.com/sites/)
 
 Once configured and when site is regenerated, the header should be there.

--- a/templates/_includes/claim_yandex.html
+++ b/templates/_includes/claim_yandex.html
@@ -1,0 +1,1 @@
+        <meta name="yandex-verification" content="{{ CLAIM_YANDEX }}" />

--- a/templates/article.html
+++ b/templates/article.html
@@ -115,7 +115,7 @@
             {% if article.date %}
             <h4>Published</h4>
             {% set day = article.date.strftime('%d')|int %}
-            <time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.date.strftime('%b') }} {{ day }} {{- article.date.strftime(', %Y') }}</time>
+            <time itemprop="dateCreated" datetime="{{ article.date.isoformat() }}">{{ article.locale_date }}</time>
             {% endif %}
             {% include '_includes/last_updated.html' %}
             {% include '_includes/series.html' %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,26 @@
         <meta name="author" content="{{ AUTHOR }}" />
         {% endif %}
 
+        {% if not article %}
+        <!-- Fill in SITE_DESCRIPTION-->
+        {% from '_includes/_defaults.html' import SITE_DESCRIPTION with context %}
+        {% if SITE_DESCRIPTION %}
+        <meta property="og:description" content="{{SITE_DESCRIPTION|striptags|e}}" />
+         <meta name="description" content="{{SITE_DESCRIPTION|striptags|e}}">
+        {% endif %}
+
+        <!-- Fill in Site ICON-->
+        {% from '_includes/_defaults.html' import FEATURED_IMAGE with context %}
+        {% if FEATURED_IMAGE %}
+        <meta property="og:image" content="{{FEATURED_IMAGE}}" />
+        <meta name="twitter:image" content="{{FEATURED_IMAGE}}" >
+        {% endif %}
+
+        <!-- Fill in Site Keywords-->
+        <meta name="keywords" content="{% for tag, articles in tags|sort %} {{ tag }}, {% endfor %}" />
+
+        {% endif %}
+
         {% from '_includes/_defaults.html' import SITE_DESCRIPTION with context %}
         {% if SITE_DESCRIPTION %}
         <meta name="description" content="{% block head_description %}{{ SITE_DESCRIPTION|e }}{% endblock head_description %}" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,9 @@
         {% endif %}
         {% if CLAIM_BING %}
         {% include '_includes/claim_bing.html' with context %}
-
+        {% endif %}
+        {% if CLAIM_YANDEX %}
+        {% include '_includes/claim_yandex.html' with context %}
         {% endif %}
         {% if article and article.author %}
         <meta name="author" content="{{ article.author }}" />


### PR DESCRIPTION
<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [ ] My Pull Request is filled against the `next` branch
- [ ] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [ ] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

<!--- Provide a general summary of the patch here -->
This adds meta tags for content and keywords plus the default icon for main page of website

Closes #505 