### PR TITLE
(feat): SEO: Add frontpage meta keywords tags based on all articles 

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -30,6 +30,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
         {% from '_includes/_defaults.html' import SITE_DESCRIPTION with context %}
         {% if SITE_DESCRIPTION %}
         <meta name="description" content="{% block head_description %}{{ SITE_DESCRIPTION|e }}{% endblock head_description %}" />
+        <meta name="twitter:description" content="{% block head_description2 %}{{ SITE_DESCRIPTION|e }}{% endblock head_description2 %}">
         {% endif %}
         {% block meta_tags_in_head %}
         {% from '_includes/_defaults.html' import TWITTER_USERNAME with context %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
 {% block meta_tags_in_head %}
 {{ super() }}
 {% from '_includes/_defaults.html' import LANDING_PAGE_TITLE with context %}
-{% if LANDING_PAGE_TITLE  %}
+{% if LANDING_PAGE_TITLE %}
 <meta property="og:title" content="{{ LANDING_PAGE_TITLE|e }}"/>
 <meta name="twitter:title" content="{{ LANDING_PAGE_TITLE|e }}">
 {% else %}
@@ -15,11 +15,6 @@
 <meta name="twitter:title" content="{{ SITENAME|striptags|e }}">
 {% endif %}
 <meta property="og:url" content="{{ SITEURL }}" />
-{% from '_includes/_defaults.html' import SITE_DESCRIPTION with context %}
-{% if SITE_DESCRIPTION %}
-<meta property="og:description" content="{{SITE_DESCRIPTION|e}}" />
-<meta name="twitter:description" content="{{SITE_DESCRIPTION|e}}">
-{% endif %}
 <meta property="og:site_name" content="{{ SITENAME|striptags|e }}" />
 <meta property="og:article:author" content="{{ AUTHOR }}" />
 {% from '_includes/_defaults.html' import FEATURED_IMAGE with context %}
@@ -27,6 +22,7 @@
 <meta property="og:image" content="{{FEATURED_IMAGE}}" />
 <meta name="twitter:image" content="{{FEATURED_IMAGE}}" >
 {% endif %}
+<meta name="keywords" content="{% for tag, _ in tags|sort %} {{ tag }}, {% endfor %}{% for category, _ in categories|sort %} {{ category }}, {% endfor %}" />
 {% endblock meta_tags_in_head %}
 
 {% block content %}


### PR DESCRIPTION
Signed-off-by: Pablo Iranzo Gómez <Pablo.Iranzo@gmail.com>

<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [x] My Pull Request is filled against the `next` branch
- [x] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [x] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

<!--- Provide a general summary of the patch here -->
This adds meta tags for content and keywords plus the default icon for main page of website

Closes #505