### PR TITLE
feat(sharing): Enable customizing the sharing links

### DIFF
--- a/documentation/content/Supported Plugins/share-post-plugin.md
+++ b/documentation/content/Supported Plugins/share-post-plugin.md
@@ -35,6 +35,16 @@ configuration variable in your Pelican configuration.
 PLUGINS = ['share_post']
 ```
 
+Optionally, customize the list of networks where the article can be shared using `SHARE_LINKS`.
+
+```python
+SHARE_LINKS = [ ('twitter', 'Twitter'), ('facebook', 'Facebook'), ('email', 'Email') ]
+```
+
+The first item in each pair refers to a network recognized by `share_post`. Currently the list of supported networks includes `twitter`, `facebook`, `email`, `hacker-news`, `linkedin` and `reddit`. The second item in each pair is the text displayed for the link on the page. 
+
+The sharing links are displayed in the order of `SHARE_LINKS`, therefore this variable can also be used to customize the link order.
+
 !!! note
 
     The [share_post plugin](https://github.com/getpelican/pelican-plugins/blob/master/share_post/README.md) requires the Python `beautifulsoup4` package to be installed.

--- a/documentation/pelicanconf.py
+++ b/documentation/pelicanconf.py
@@ -122,6 +122,10 @@ SITE_DESCRIPTION = (
     "Documentation of Elegant, a theme for Pelican, originally created by Talha Mansoor"
 )
 
+# Share links at bottom of articles
+# Supported: twitter, facebook, hacker-news, reddit, linkedin, email
+SHARE_LINKS = [ ('twitter', 'Twitter'), ('facebook', 'Facebook'), ('email', 'Email') ]
+
 # Landing Page
 PROJECTS_TITLE = "Related Projects"
 PROJECTS = [

--- a/templates/_includes/_defaults.html
+++ b/templates/_includes/_defaults.html
@@ -224,3 +224,9 @@ PROJECTS = [{
 {% else %}
 {% set APPLAUSE_BUTTON = APPLAUSE_BUTTON %}
 {% endif %}
+
+{% if not SHARE_LINKS %}
+{% set SHARE_LINKS = [ ('twitter', 'Twitter'), ('facebook', 'Facebook'), ('email', 'Email') ] %}
+{% else %}
+{% set SHARE_LINKS = SHARE_LINKS %}
+{% endif %}

--- a/templates/_includes/share_links.html
+++ b/templates/_includes/share_links.html
@@ -1,5 +1,6 @@
 {% macro share_links(article) %}
-    {% if article.share_post and article.status != 'draft' %}
+    {% from '_includes/_defaults.html' import SHARE_LINKS with context %}
+    {% if article.share_post and article.status != 'draft' and SHARE_LINKS %}
     <p id="post-share-links">
     {% if article.share_post_intro %}
     {{ article.share_post_intro }}
@@ -7,11 +8,9 @@
     {% from '_includes/_defaults.html' import SHARE_POST_INTRO with context %}
     {{ SHARE_POST_INTRO }}
     {% endif %}
-    <a href="{{ article.share_post['twitter'] }}" target="_blank" rel="nofollow noopener noreferrer" title="Share on Twitter">Twitter</a>
-    ❄
-    <a href="{{ article.share_post['facebook'] }}" target="_blank" rel="nofollow noopener noreferrer" title="Share on Facebook">Facebook</a>
-    ❄
-    <a href="{{ article.share_post['email'] }}" target="_blank" rel="nofollow noopener noreferrer" title="Share via Email">Email</a>
-    </p>
+    {% for network, label in SHARE_LINKS %}
+      {% if not loop.first %} ❄ {% endif %}
+      <a href="{{ article.share_post[network] }}" target="_blank" rel="nofollow noopener noreferrer" title="Share {% if network == 'email' %}via{% else %}on{% endif %} {{ label }}">{{ label }}</a>
+    {% endfor %}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Previously the sharing links were fixed at twitter, facebook, email.
This patch makes it possible to opt in and out of the networks
supported by the share_post plug-in, and change the order of the links.
