### PR TITLE
fix(perf): remove a nested loop in the tag list generation

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -130,9 +130,8 @@
             <ul class="list-of-tags tags-in-article">
                 {% for tag in article.tags|sort %}
                 <li><a href="{{ SITEURL }}/{{ TAGS_URL }}#{{ tag.slug }}-ref">{{ tag }}
-                    {% for aTag, tagged_articles in tags if aTag == tag %}
-                    <span class="superscript">{{ tagged_articles|count }}</span>
-                    {% endfor %}</a></li>
+                    <span class="superscript">{{ tags[tag]|count }}</span>
+                    </a></li>
                 {% endfor %}
             </ul>
             {% endif %}


### PR DESCRIPTION
This patch removes the nested loop in the generation of the tag list
alongside an article. It makes uses of the fact that `tags` is a
dictionary.

On my computer this reduces the generation time of the documentation
site from 73s to 70s.

(This PR is related to #145. Even though it removes the nested loop,
I feel that it does not fully close the issue because the generation
performance remains low. Someone will need to profile this again and
find out what is the next bottleneck.)

Informs #145

