### PR TITLE
(feat) use semver to bump major/minor releases when a new one is done

### DIFF
--- a/.github/workflows/update_semver.yml
+++ b/.github/workflows/update_semver.yml
@@ -1,0 +1,15 @@
+name: Update Semver
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'V*.*.*'
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haya14busa/action-update-semver@v1
+        with:
+          major_version_tag_only: false  # (optional, default is "false")


### PR DESCRIPTION
<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [x] My Pull Request is filled against the `next` branch
- [ ] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [ ] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

<!--- Provide a general summary of the patch here -->

Enables GHA that bumps V5  and V5.X when V5.0.1 is releases, automating the creation of tags and allowing users to match against a specific major or minor without having to wonder on subminors