### PR TITLE
fix: allow PLUGINS to be None

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         {% block head_links %}
-        {% if 'assets' in PLUGINS %}
+        {% if PLUGINS and 'assets' in PLUGINS %}
         {% include '_includes/minify_css.html' with context %}
         {% else %}
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/elegant.prod.9e9d5ce754.css" media="screen">

--- a/templates/search.html
+++ b/templates/search.html
@@ -39,7 +39,7 @@ Search results for {{ SITENAME|striptags|e }} blog.
 {% endblock content %}
 
 {% block script %}
-    {% if 'tipue_search' in PLUGINS %}
+    {% if PLUGINS and 'tipue_search' in PLUGINS %}
         <script src="{{ SITEURL }}/tipuesearch_content.js"></script>
     {% endif %}
 {{ super() }}


### PR DESCRIPTION
## Prerequisites

- [x] My Pull Request is filled against the `next` branch
- [x] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [ ] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

With a fairly fresh setup of Pelican (I'm a Pelican n00b), I tried the elegant theme and the dev web server was emitting this message --
```
WARNING: Caught exception:
  | "argument of type 'NoneType' is not iterable".
```

I traced it to the fact that `PLUGINS` variable was at its default (`None`, see https://docs.getpelican.com/en/stable/settings.html#basic-settings) and the theme was assuming otherwise in a couple of places. 
