### PR TITLE
feat(article.html): add ld+json information about article

### DIFF
--- a/templates/_includes/snippets.html
+++ b/templates/_includes/snippets.html
@@ -1,0 +1,40 @@
+{% macro snippets(article) %}
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org/",
+        "@type": "NewsArticle",
+
+        "author": {
+            "@type": "Person",
+            "name": "{{ article.author }}"
+        },
+
+        "datePublished": "{{ article.date.isoformat() }}",
+        {% if article.modified %}
+        "dateModified": "{{ article.modified.isoformat() }}",
+        {% endif %}
+        "description": "{{ article.summary|striptags|e }}",
+
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "{{ SITEURL }}/{{ article.url }}"
+        },
+
+        "headline": "{{ article.title|striptags|e }}",
+        {% if article.featured_image %}
+            "image": [{{ article.featured_image }}],
+        {% endif %}
+
+        "publisher": {
+            "@type": "Organization",
+            "name": "{{ SITENAME|striptags|e }}"
+            {%if FEATURED_IMAGE %}
+            , "logo": {
+                "@type": "ImageObject",
+                "url": "{{ FEATURED_IMAGE }}"
+            }
+            {% endif %}
+        }
+    }
+</script>
+{% endmacro %}

--- a/templates/article.html
+++ b/templates/article.html
@@ -21,6 +21,9 @@
 
 {% from '_includes/smo_metadata.html' import smo_metadata with context %}
 {{ smo_metadata(article) }}
+
+{% from '_includes/snippets.html' import snippets with context %}
+{{ snippets(article) }}
 {% endblock meta_tags_in_head %}
 
 {% block head_links %}


### PR DESCRIPTION
Closes #287

<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [x] My Pull Request is filled against the `next` branch
- [ ] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [x] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

Adds a ld+json header for articles based on https://developers.google.com/search/docs/data-types/article
<!--- Provide a general summary of the patch here -->
