### PR TITLE
feat(translations): add menuitems translations

### DIFF
--- a/templates/_includes/_defaults.html
+++ b/templates/_includes/_defaults.html
@@ -236,3 +236,21 @@ PROJECTS = [{
 {% else %}
 {% set SHARE_LINKS = SHARE_LINKS %}
 {% endif %}
+
+
+{% if not HOME_MENUITEM %}
+{% set HOME_MENUITEM = 'Home' %}
+{% else %}
+{% set HOME_MENUITEM = HOME_MENUITEM %}
+{% endif %}
+
+
+{% if not MENUITEMS %}
+{% set MENUITEMS = (
+    ('categories', 'Categories', CATEGORIES_URL),
+    ('tags', 'Tags', TAGS_URL),
+    ('archives', 'Archives', ARCHIVES_URL),
+) %}
+{% else %}
+{% set MENUITEMS = MENUITEMS %}
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,6 +64,7 @@
                         <a class="brand" href="{{ SITEURL }}/"><span class=site-name>{{ SITENAME }}</span></a>
                         <div class="nav-collapse collapse">
                             <ul class="nav pull-right top-menu">
+                                {% from '_includes/_defaults.html' import HOME_MENUITEM with context %}
                                 <li {% if page_name == 'index' %} class="active"{% endif %}>
                                     <a href=
                                        {% if SITEURL %}
@@ -71,17 +72,17 @@
                                        {% else %}
                                        "/"
                                        {% endif %}
-                                    >Home</a>
+                                    >{{ HOME_MENUITEM }}</a>
                                 </li>
                                 {% if DISPLAY_PAGES_ON_MENU %}
                                 {% for p in pages %}
                                 <li {% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
                                 {% endfor %}
                                 {% endif %}
-                                {% from '_includes/_defaults.html' import TAGS_URL, CATEGORIES_URL, ARCHIVES_URL, SEARCH_URL with context %}
-                                <li {% if page_name == 'categories' %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}">Categories</a></li>
-                                <li {% if page_name == 'tags' %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ TAGS_URL }}">Tags</a></li>
-                                <li {% if page_name == 'archives' %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ ARCHIVES_URL }}">Archives</a></li>
+                                {% from '_includes/_defaults.html' import MENUITEMS with context %}
+                                {% for name, title, link in MENUITEMS %}
+                                    <li {% if page_name == name %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ link }}">{{ title }}</a></li>
+                                {% endfor %}
                                 <li><form class="navbar-search" action="{{ SITEURL }}/{{ SEARCH_URL }}" onsubmit="return validateForm(this.elements['q'].value);"> <input type="text" class="search-query" placeholder="Search" name="q" id="tipue_search_input"></form></li>
                             </ul>
                         </div>


### PR DESCRIPTION
<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [ ] My Pull Request is filled against the `next` branch
- [x] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [ ] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

<!--- Provide a general summary of the patch here -->
Now it's possible to define custom values for menuitems. Home is separated from the rest since you have the ability to add pages as menu item between them.

```python
HOME_MENUITEM = 'Inicio'

MENUITEMS = (
    ('categories', 'Categorías', CATEGORIES_URL),
    ('tags', 'Etiquetas', TAGS_URL),
    ('archives', 'Archivos', ARCHIVES_URL),
)
```
first value in tuple is needed to enable active class of the menu item
![image](https://user-images.githubusercontent.com/12305218/123692789-87fa1500-d857-11eb-8229-1614810290cb.png)

