### PR TITLE
feat(translations): Add search placeholder translations

### DIFF
--- a/templates/_includes/_defaults.html
+++ b/templates/_includes/_defaults.html
@@ -236,3 +236,15 @@ PROJECTS = [{
 {% else %}
 {% set SHARE_LINKS = SHARE_LINKS %}
 {% endif %}
+
+{% if not SEARCH_PLACEHOLDER %}
+{% set SEARCH_PLACEHOLDER = 'Search' %}
+{% else %}
+{% set SEARCH_PLACEHOLDER = SEARCH_PLACEHOLDER %}
+{% endif %}
+
+{% if not SEARCH_TAG_PLACEHOLDER %}
+{% set SEARCH_TAG_PLACEHOLDER = 'Find a tag' %}
+{% else %}
+{% set SEARCH_TAG_PLACEHOLDER = SEARCH_TAG_PLACEHOLDER %}
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,11 +78,11 @@
                                 <li {% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
                                 {% endfor %}
                                 {% endif %}
-                                {% from '_includes/_defaults.html' import TAGS_URL, CATEGORIES_URL, ARCHIVES_URL, SEARCH_URL with context %}
+                                {% from '_includes/_defaults.html' import TAGS_URL, CATEGORIES_URL, ARCHIVES_URL, SEARCH_URL, SEARCH_PLACEHOLDER with context %}
                                 <li {% if page_name == 'categories' %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}">Categories</a></li>
                                 <li {% if page_name == 'tags' %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ TAGS_URL }}">Tags</a></li>
                                 <li {% if page_name == 'archives' %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ ARCHIVES_URL }}">Archives</a></li>
-                                <li><form class="navbar-search" action="{{ SITEURL }}/{{ SEARCH_URL }}" onsubmit="return validateForm(this.elements['q'].value);"> <input type="text" class="search-query" placeholder="Search" name="q" id="tipue_search_input"></form></li>
+                                <li><form class="navbar-search" action="{{ SITEURL }}/{{ SEARCH_URL }}" onsubmit="return validateForm(this.elements['q'].value);"> <input type="text" class="search-query" placeholder="{{ SEARCH_PLACEHOLDER }}" name="q" id="tipue_search_input"></form></li>
                             </ul>
                         </div>
                     </div>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -30,7 +30,7 @@ All tags used in the {{ SITENAME|striptags|e }} blog.
 {% endblock feed_links %}
 
 {% block content %}
-{% from '_includes/_defaults.html' import TAGS_URL with context %}
+{% from '_includes/_defaults.html' import TAGS_URL, SEARCH_TAG_PLACEHOLDER with context %}
 <div class="row-fluid">
     <header class="page-header span10 offset2">
     <h1><a href="{{ SITEURL }}/{{ TAGS_URL }}">All Tags</a></h1>
@@ -39,7 +39,7 @@ All tags used in the {{ SITENAME|striptags|e }} blog.
 <div class="row-fluid">
     <div class="span8 offset2">
         <form class="form-search">
-            <input type="text" class="input-medium search-query filterinput" placeholder="Find a tag">
+            <input type="text" class="input-medium search-query filterinput" placeholder="{{ SEARCH_TAG_PLACEHOLDER }}">
         </form>
         <ul class="list-of-tags">
             {% for tag, articles in tags|sort %}


### PR DESCRIPTION
<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [ ] My Pull Request is filled against the `next` branch
- [x] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [ ] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

<!--- Provide a general summary of the patch here -->
Tranlations for the search placeholders, adding the following code to the `pelicanconf.py`:
```
SEARCH_PLACEHOLDER = 'Buscar'
SEARCH_TAG_PLACEHOLDER = 'Buscar etiqueta'
```

![image](https://user-images.githubusercontent.com/12305218/126037814-e71c6564-14f4-4b38-a338-034046c20f82.png)
