### PR TITLE
docs: fix some typos and formatting in the docs

### DIFF
--- a/documentation/content/101 Quick Start/updating-new-releases.md
+++ b/documentation/content/101 Quick Start/updating-new-releases.md
@@ -83,7 +83,7 @@ git pull origin master
 ```
 
 Note that this is the most effective way of updating your standalone repository if you
-have not made any changes to the the theme. If you have made some changes, you may be
+have not made any changes to the theme. If you have made some changes, you may be
 required to merge the changes in your local repository with any changes in the release
 version you pulled down with this command.
 

--- a/documentation/content/Advanced Features/custom-404.md
+++ b/documentation/content/Advanced Features/custom-404.md
@@ -22,7 +22,7 @@ To enable the custom 404 page, you need to add `404` to `DIRECT_TEMPLATES` in yo
 configuration.
 
 ```python
-DIRECT_TEMPLATES = ['404']
+DIRECT_TEMPLATES = ["404"]
 ```
 
 Note that these values must be added to any existing values present for the `DIRECT_TEMPLATES`

--- a/documentation/content/Advanced Features/tipue-search.md
+++ b/documentation/content/Advanced Features/tipue-search.md
@@ -27,8 +27,8 @@ To enable search, you need to enable the `tipue_search` plugin and add `search` 
 `DIRECT_TEMPLATES` in your pelican configuration.
 
 ```python
-PLUGINS = ['tipue_search']
-DIRECT_TEMPLATES = ['search']
+PLUGINS = ["tipue_search"]
+DIRECT_TEMPLATES = ["search"]
 ```
 
 Note that these values must be added to any existing values present for the `PLUGINS` and

--- a/documentation/content/Analytics SEO SMO/ms-clarity.md
+++ b/documentation/content/Analytics SEO SMO/ms-clarity.md
@@ -3,8 +3,8 @@ Title: How to use Microsoft Clarity
 Tags: web-analytics
 Category: Analytics, SEO and SMO
 Date: 2021-01-25 20:05
-Slug: how-to-use-microsoft-clarity
-Comment_id: cf14ac5-how-to-use-microsoft-clarity
+Slug: how-to-use-Microsoft-clarity
+Comment_id: cf14ac5-how-to-use-Microsoft-clarity
 Subtitle:
 Summary: Elegant Pelican theme supports Microsoft Clarity out of the box. This articles describes how to set it up.
 Keywords:

--- a/documentation/content/Components/filter-tags.md
+++ b/documentation/content/Components/filter-tags.md
@@ -1,8 +1,8 @@
 ---
 authors: Talha Mansoor
 Title: Live Filter for Tags
-Tags: nuances, search
 layout: post
+Tags: nuances, search
 Date: 2013-08-27 23:20
 comments: false
 Slug: live-filter-for-tags

--- a/documentation/content/Components/hosted-on.md
+++ b/documentation/content/Components/hosted-on.md
@@ -19,10 +19,7 @@ To do so, define a dictionary `HOSTED_ON` in your Pelican configuration. It has 
 For example,
 
 ```python
-HOSTED_ON = {
-    "name": "Netlify",
-    "url": "https://www.netlify.com/"
-    }
+HOSTED_ON = {"name": "Netlify", "url": "https://www.netlify.com/"}
 ```
 
 It will appear in the footer as

--- a/documentation/content/Components/line-numbers-code-snippet.md
+++ b/documentation/content/Components/line-numbers-code-snippet.md
@@ -28,7 +28,7 @@ markup. Use `linenos` flag to switch on line numbers for the snippet.
         :linenos:
 
         def example():
-            print 'Hello World'
+            print "Hello World"
 
 ## Markdown
 

--- a/documentation/content/Components/permalink.md
+++ b/documentation/content/Components/permalink.md
@@ -10,22 +10,18 @@ Keywords:
 First, you need to enable the `toc` extension for Markdown in your Pelican configuration.
 
 ```python
-MARKDOWN = {
-  'extension_configs': {
-    'markdown.extensions.toc': {}
-  }
-}
+MARKDOWN = {"extension_configs": {"markdown.extensions.toc": {}}}
 ```
 
 Then enable `permalink` option available for the `toc` extension.
 
 ```python
 MARKDOWN = {
-  'extension_configs': {
-    'markdown.extensions.toc': {
-      'permalink': 'true',
+    "extension_configs": {
+        "markdown.extensions.toc": {
+            "permalink": "true",
+        }
     }
-  }
 }
 ```
 
@@ -48,10 +44,10 @@ You would get this,
 
 ```python
 MARKDOWN = {
-  'extension_configs': {
-    'markdown.extensions.toc': {
-      'permalink': ' ',
+    "extension_configs": {
+        "markdown.extensions.toc": {
+            "permalink": " ",
+        }
     }
-  }
 }
 ```

--- a/documentation/content/Components/table-of-contents.md
+++ b/documentation/content/Components/table-of-contents.md
@@ -37,7 +37,7 @@ For the second step, you need to enable the `extract_toc` plugin in
 your pelican configuration.
 
 ```python
-PLUGINS = ['extract_toc']
+PLUGINS = ["extract_toc"]
 ```
 
 ## Configuring Markdown
@@ -45,11 +45,7 @@ PLUGINS = ['extract_toc']
 You need to enable the `toc` extension for Markdown in your Pelican configuration.
 
 ```python
-MARKDOWN = {
-  'extension_configs': {
-    'markdown.extensions.toc': {}
-  }
-}
+MARKDOWN = {"extension_configs": {"markdown.extensions.toc": {}}}
 ```
 
 Now to generate a table of contents for you article, add the `[TOC]` markdown tag to your

--- a/documentation/content/Connecting With Your Readers/social-profiles-sidebar-svg.md
+++ b/documentation/content/Connecting With Your Readers/social-profiles-sidebar-svg.md
@@ -53,7 +53,7 @@ has three items,
 
 ```python
 SOCIAL = (
-    ('Email', 'example@example.com', 'My Email Address'),
+    ("Email", "example@example.com", "My Email Address"),
     ("Github", "https://github.com/Pelican-Elegant/", "Elegant Github Repository"),
     ("RSS", SITEURL + "/feeds/all.atom.xml"),
     ("Facebook", "https://facebook.com/ExamplePage/"),

--- a/documentation/content/Supported Plugins/assets-plugin.md
+++ b/documentation/content/Supported Plugins/assets-plugin.md
@@ -35,7 +35,7 @@ To enable Asset Management for your website, add `assets` to the `PLUGINS` confi
 variable in your Pelican configuration.
 
 ```python
-PLUGINS = ['assets']
+PLUGINS = ["assets"]
 ```
 
 !!! note

--- a/documentation/content/Supported Plugins/multi-part-plugin.md
+++ b/documentation/content/Supported Plugins/multi-part-plugin.md
@@ -38,7 +38,7 @@ To enable the reading time for your articles, you need to add `multi-part` to th
 configuration variable in your Pelican configuration.
 
 ```python
-PLUGINS = ['multi-part']
+PLUGINS = ["multi-part"]
 ```
 
 In addition, the `SERIES_TITLE` configuration variable can be set to specify the title used for

--- a/documentation/content/Supported Plugins/photogallery.md
+++ b/documentation/content/Supported Plugins/photogallery.md
@@ -41,7 +41,7 @@ To enable the Photo Gallery plugin, add `photos` to the `PLUGINS` configuration 
 your Pelican configuration.
 
 ```python
-PLUGINS = ['photos']
+PLUGINS = ["photos"]
 ```
 
 !!! note
@@ -83,13 +83,13 @@ In the above example, the actual directory containing the images to display is t
 `dragondance` directory. While not specified in the example, the directory `articles` and the
 directory `gallery-source` are at the same directory depth, one directory to contain articles
 and one directory to contain galleries. By that convention, the article containing the
-`gallery` metadata is located in the the `articles` directory. Therefore, the path to the
+`gallery` metadata is located in the `articles` directory. Therefore, the path to the
 directory containing the `dragondance` directory is `../gallery-source/`. Together, the entire
 path to the `dragondance` directory from the article becomes `../gallery-source/dragondance`.
 
 ### Photo Gallery Titles
 
-Titles for a photo gallery are displayed in a large font directly above the first row of the
+The titles for a photo gallery are displayed in a large font directly above the first row of the
 photo gallery. To specify the title for a gallery, add the required title to the metadata in
 the `gallery` metadata field within curly braces ('{' and '}') as follows:
 

--- a/documentation/content/Supported Plugins/previous-and-next-article.md
+++ b/documentation/content/Supported Plugins/previous-and-next-article.md
@@ -28,7 +28,7 @@ To enable the Previous and Next Article links for your articles, add `neighbors`
 `PLUGINS` configuration variable in your Pelican configuration.
 
 ```python
-PLUGINS = ['neighbors']
+PLUGINS = ["neighbors"]
 ```
 
 When enabled, Elegant will show the links for Previous and Next articles at the very bottom of

--- a/documentation/content/Supported Plugins/reading-time.md
+++ b/documentation/content/Supported Plugins/reading-time.md
@@ -26,7 +26,7 @@ To enable the reading time for your articles, you need to add `post_stats` to th
 configuration variable in your Pelican configuration.
 
 ```python
-PLUGINS = ['post_stats']
+PLUGINS = ["post_stats"]
 ```
 
 !!! note

--- a/documentation/content/Supported Plugins/series-plugin.md
+++ b/documentation/content/Supported Plugins/series-plugin.md
@@ -36,7 +36,7 @@ To enable the reading time for your articles, you need to add `series` to the `P
 configuration variable in your Pelican configuration.
 
 ```python
-PLUGINS = ['series']
+PLUGINS = ["series"]
 ```
 
 In addition, the `SERIES_TITLE` configuration variable can be set to specify the title used for

--- a/documentation/content/Supported Plugins/share-post-plugin.md
+++ b/documentation/content/Supported Plugins/share-post-plugin.md
@@ -32,13 +32,13 @@ To enable the Social Media Sharing links for your articles, add `share_post` to 
 configuration variable in your Pelican configuration.
 
 ```python
-PLUGINS = ['share_post']
+PLUGINS = ["share_post"]
 ```
 
 Optionally, customize the list of networks where the article can be shared using `SHARE_LINKS`.
 
 ```python
-SHARE_LINKS = [ ('twitter', 'Twitter'), ('facebook', 'Facebook'), ('email', 'Email') ]
+SHARE_LINKS = [("twitter", "Twitter"), ("facebook", "Facebook"), ("email", "Email")]
 ```
 
 The first item in each pair refers to a network recognized by `share_post`. Currently the list of supported networks includes `twitter`, `facebook`, `email`, `hacker-news`, `linkedin` and `reddit`. The second item in each pair is the text displayed for the link on the page.


### PR DESCRIPTION
<!--
    ----------^ Click "Preview" for a nicer view!
-->

<!--
    Thank you very much for contributing to Pelican-Elegant! ❤️
-->

## Prerequisites

- [x] My Pull Request is filled against the `next` branch
- [ ] All commits in my Pull Request conform to [Elegant Git commit Guidelines](https://elegant.oncrashreboot.com/git-commit-guidelines)

## Recommended Steps

<!---
    These are not mandatory and will NOT negatively effect our patch review process.
    But we encourage you to do them.
-->

- [ ] My patch adds a new feature, therefore I have also added a help article about it
- [ ] My patch changes Elegant behavior, therefore I have updated the help article to reflect this change
- [x] My commits are [signed](https://help.github.com/en/articles/signing-commits)

## Description

Fixes some typos, and duplicate words reported by yaspeller as well as some formatting recommendations applied by black/pre-commit
